### PR TITLE
Fixed compatability issue with newer versions of MATLAB

### DIFF
--- a/src/adrem/predict_adrem.m
+++ b/src/adrem/predict_adrem.m
@@ -56,7 +56,7 @@ function [y_tgt,ys_tgt,models] = predict_adrem(x_src,y_src,x_tgt, varargin)
           end
           % sample once without replacement
           % the rest: copy all samples
-          copies = idivide(n_i, length(which_i));
+          copies = idivide(int32(n_i), int32(length(which_i)));
           idx = [repmat(1:length(which_i), 1, copies), randperm(length(which_i), n_i-copies*length(which_i))];
           which_tgt = [which_tgt; which_i(idx(:))];
         end


### PR DESCRIPTION
This is a fix for newer versions of MATLAB. For example in MATLAB 2018a, the output of `ceil` and `length` may be doubles, making the check `isinteger` fail. This fix preserves backward compatibility.